### PR TITLE
removed non-existent pymatgen convenience imports

### DIFF
--- a/pycdt/core/chemical_potentials.py
+++ b/pycdt/core/chemical_potentials.py
@@ -15,7 +15,8 @@ __date__ = "Sep 14, 2014"
 import os
 import logging
 
-from pymatgen import Structure, Element
+from pymatgen.core.periodic_table import Element
+from pymatgen.core.structure import Structure
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.ext.matproj import MPRester
 from pymatgen.io.vasp.outputs import Vasprun

--- a/pycdt/core/defects_analyzer.py
+++ b/pycdt/core/defects_analyzer.py
@@ -15,7 +15,7 @@ from itertools import combinations
 import os
 import numpy as np
 
-from pymatgen.core import Element
+from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import PeriodicSite, Structure
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/pycdt/core/tests/test_chemical_potentials.py
+++ b/pycdt/core/tests/test_chemical_potentials.py
@@ -22,7 +22,8 @@ from monty.tempfile import ScratchDir
 from pycdt.core.chemical_potentials import ChemPotAnalyzer, MPChemPotAnalyzer, \
     UserChemPotAnalyzer, UserChemPotInputGenerator, get_mp_chempots_from_dpd
 
-from pymatgen.core import Composition, Element
+from pymatgen.core.composition import Composition
+from pymatgen.core.periodic_table import Element
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.defects.thermodynamics import DefectPhaseDiagram
 from pymatgen.entries.computed_entries import ComputedEntry

--- a/pycdt/core/tests/test_defects_analyzer.py
+++ b/pycdt/core/tests/test_defects_analyzer.py
@@ -21,7 +21,7 @@ from monty.json import MontyDecoder, MontyEncoder
 from monty.tempfile import ScratchDir
 
 from pymatgen import __file__ as initfilep
-from pymatgen.core import Element
+from pymatgen.core.periodic_table import Element
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.lattice import Lattice
 from pymatgen.entries.computed_entries import ComputedStructureEntry

--- a/pycdt/core/tests/test_defectsmaker.py
+++ b/pycdt/core/tests/test_defectsmaker.py
@@ -13,7 +13,7 @@ __date__ = "June 6, 2016"
 import os
 
 from pymatgen.core.structure import Structure
-from pymatgen.core import PeriodicSite
+from pymatgen.core.sites import PeriodicSite
 from pycdt.core.defectsmaker import *
 from pymatgen.util.testing import PymatgenTest
 

--- a/pycdt/utils/parse_calculations.py
+++ b/pycdt/utils/parse_calculations.py
@@ -20,7 +20,8 @@ import numpy as np
 from monty.serialization import loadfn, dumpfn
 from monty.json import MontyEncoder, MontyDecoder
 
-from pymatgen.core import PeriodicSite, Structure
+from pymatgen.core.sites import PeriodicSite
+from pymatgen.core.structure import Structure
 from pymatgen.ext.matproj import MPRester
 from pymatgen.io.vasp.outputs import Vasprun, Locpot, Outcar, Poscar
 from pymatgen.io.vasp.inputs import Potcar

--- a/pycdt/utils/tests/test_parse_calculations.py
+++ b/pycdt/utils/tests/test_parse_calculations.py
@@ -22,7 +22,8 @@ from monty.json import MontyEncoder
 from monty.tempfile import ScratchDir
 
 from pymatgen import __file__ as initfilep
-from pymatgen.core import Element, PeriodicSite
+from pymatgen.core.periodic_table import Element 
+from pymatgen.core.sites import PeriodicSite
 from pymatgen.io.vasp import Vasprun, Locpot
 from pymatgen.analysis.defects.core import DefectEntry, Vacancy, Substitution
 from pymatgen.entries.computed_entries import ComputedStructureEntry

--- a/pycdt/utils/tests/test_plotter.py
+++ b/pycdt/utils/tests/test_plotter.py
@@ -12,7 +12,7 @@ __date__ = "July 19, 2017"
 
 import os
 
-from pymatgen.core import Element
+from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import PeriodicSite, Structure, Lattice
 from pymatgen.util.testing import PymatgenTest
 from pymatgen.analysis.defects.core import Vacancy, DefectEntry

--- a/pycdt/utils/vasp.py
+++ b/pycdt/utils/vasp.py
@@ -19,7 +19,7 @@ from monty.serialization import loadfn, dumpfn
 from monty.json import MontyEncoder
 from monty.os.path import zpath
 
-from pymatgen import SETTINGS
+from pymatgen.core import SETTINGS
 from pymatgen.io.vasp.inputs import Kpoints
 from pymatgen.io.vasp.sets import MPRelaxSet, MPStaticSet
 from pymatgen.io.vasp.inputs import PotcarSingle, Potcar

--- a/scripts/pycdt
+++ b/scripts/pycdt
@@ -30,7 +30,7 @@ from monty.serialization import dumpfn, loadfn
 from monty.json import MontyEncoder, MontyDecoder
 
 from pymatgen.ext.matproj import MPRester
-from pymatgen.core import Element
+from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.io.vasp.inputs import Incar


### PR DESCRIPTION
Removed the "convenience imports" from pymatgen or pymatgen.core, which are no longer possible in pymatgen v2022 (this was a breaking change of Pymatgen)