### PR TITLE
Cap maximum version of pymatgen

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         name="pycdt",
         packages=find_packages(),
         version="2.0.5",
-        install_requires=["numpy>=1.18.15", "pymatgen>=2020.6.8", "matplotlib>=3.1""monty>=3.0.2"],
+        install_requires=["numpy>=1.18.15", "pymatgen>=2020.6.8,<=2022.7.8", "matplotlib>=3.1""monty>=3.0.2"],
         package_data={"pycdt.utils": ["*.yaml"]},
         author="Danny Broberg, Bharat Medasani, Nils Zimmerman",
         author_email="mbkumar@gmail.com",


### PR DESCRIPTION
The defects module of pymatgen has some changes and will be replaced soon.
Locking this will prevent import problems.